### PR TITLE
Fix CIT build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,10 @@ pytest
 pytest-cov
 numpy
 cython
+h5py
+lalsuite
+lscsoft-glue
+matplotlib
+python-ligo-lw
+scipy
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 coverage
 pytest
 pytest-cov
+numpy
+cython

--- a/sbank/overlap_cpu_lib.c
+++ b/sbank/overlap_cpu_lib.c
@@ -113,7 +113,7 @@ static WS *get_workspace(WS *workspace_cache, const size_t n) {
 }
 
 /* by default, complex arithmetic will call built-in function __muldc3, which does a lot of error checking for inf and nan; just do it manually */
-static void multiply_conjugate(float complex * out, float complex *a, float complex *b, const size_t size) {
+static void multiply_conjugate(float complex * restrict out, float complex *a, float complex *b, const size_t size) {
     size_t k = 0;
     for (;k < size; ++k) {
         const float ar = crealf(a[k]);

--- a/sbank/overlap_cpu_lib.c
+++ b/sbank/overlap_cpu_lib.c
@@ -113,7 +113,7 @@ static WS *get_workspace(WS *workspace_cache, const size_t n) {
 }
 
 /* by default, complex arithmetic will call built-in function __muldc3, which does a lot of error checking for inf and nan; just do it manually */
-static void multiply_conjugate(float complex * restrict out, float complex *a, float complex *b, const size_t size) {
+static void multiply_conjugate(float complex * out, float complex *a, float complex *b, const size_t size) {
     size_t k = 0;
     for (;k < size; ++k) {
         const float ar = crealf(a[k]);

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = sbank
 author = The Sbank team
 maintainer = Ian Harry
-maintainer-email = ian.harry@ligo.org
+maintainer_email = ian.harry@ligo.org
 description = A library for generating template banks of compact binary mergers for gravitational-wave searches using the "stochastic" placement algorithm
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ cython_compile_args = [
     "-w",
     "-ffast-math",
     "-ffinite-math-only",
+    "-std=c99",
 ]
 cython_directives = {
     "embedsignature": True,


### PR DESCRIPTION
This fixes two issues reported by Gianluca Guidi:

 * requirements.txt does not contain cython and numpy (which are required)
 * The restrict keyword is not understood by the CIT compiler. This would only be a minor speed improvement (I think), and I don't properly have time to figure out how to get around this, so I just remove it.