### PR TITLE
Ensure npts is an int in tau0tau3

### DIFF
--- a/sbank/tau0tau3.py
+++ b/sbank/tau0tau3.py
@@ -261,7 +261,7 @@ def tau0tau3_bound(flow, **constraints):
     # FIXME: As this is discrete, this can cause the bank sizes to be smaller
     # than expected. Raising this to 1e5, raising it higher starts to cause
     # slowdown as computing m2 from m1 and mchirp is expensive.
-    npts = 1e4
+    npts = int(1e4)
 
     # draw constant component mass lines
     m1min, m1max = constraints['mass1']


### PR DESCRIPTION
Another code-has-become-broken-by-updating-dependencies issue. Here npts is intended to be an int, but is not, so cast to int.

(@titodalcanton I'm going to assign some of these sbank patches to you .... Also, there's a standalone sbank repo. now!)