### PR TITLE
Strings/bytes confusion in hdf files in python3

### DIFF
--- a/bin/sbank
+++ b/bin/sbank
@@ -487,7 +487,7 @@ if opts.trial_waveforms:
                 for name in hdf_fp:
                     tmp[name] = hdf_fp[name][idx:end_idx]
             c_idx = idx % 100000
-            approx = hdf_fp['approximant'][c_idx]
+            approx = (hdf_fp['approximant'][c_idx]).decode('utf-8')
             tmplt_class = waveforms[approx]
             proposal.append(tmplt_class.from_dict(tmp, c_idx, bank))
         hdf_fp.close()

--- a/sbank/bank.py
+++ b/sbank/bank.py
@@ -133,7 +133,7 @@ class Bank(object):
                 for name in hdf_fp:
                     tmp[name] = hdf_fp[name][idx:end_idx]
             c_idx = idx % 100000
-            approx = tmp['approximant'][c_idx]
+            approx = tmp['approximant'][c_idx].decode('utf-8')
             tmplt_class = waveforms.waveforms[approx]
             newtmplts.append(tmplt_class.from_dict(tmp, c_idx, self))
             newtmplts[-1].is_seed_point = True


### PR DESCRIPTION
Same problem as we've hit repeatedly in pycbc. Here we currently use `bytes` to store the approximant field in the output files, so if we stick with that, it needs decoding on read-in.