### PR TITLE
Don't try and make a DAX file in this script

### DIFF
--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -66,7 +66,6 @@ class bank_DAG(pipeline.CondorDAG):
         fh.close()
         pipeline.CondorDAG.__init__(self,logfile, dax=False)
         self.set_dag_file(self.basename)
-        self.set_dax_file(self.basename)
         self.jobsDict = {}
         self.node_id = 0
         self.output_cache = []


### PR DESCRIPTION
pipeline.py's DAX stuff is broken anyway, and should never be called. Use pycbc.workflow if you *want* to do this (there is also a PyCBC sbank dax generator).