### PR TITLE
Auto-upload to pypi on release

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==1.9.0
+      - name: Install required dependencies
+        run: python -m pip install h5py lalsuite lscsoft-glue matplotlib numpy python-ligo-lw scipy six
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,7 +29,7 @@ jobs:
           # lalsuite currently not available on python3.9. It should be in the
           # very near future though, so add cp39-* here when it is!
           CIBW_BUILD: cp36-* cp37-* cp38-*
-          COBW_ARCHS: auto64
+          CIBW_ARCHS: auto64
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+          CIBW_BEFORE_BUILD: pip install lalsuite
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -50,6 +50,7 @@ jobs:
         path: ./
     - name: build pycbc for pypi
       run: |
+        pip install -r requirements.txt
         python setup.py sdist
         mv artifact/* dist/
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_BUILD: pip install lalsuite
+          # This BEFORE_BUILD is a horrible hack. I need to be able to link
+          # against the lal library. However, the lal library installed through
+          # pip is hard to link against. This symlinks it into /usr/lib so
+          # that it can be found.
+          CIBW_BEFORE_BUILD: ln -s `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        # Needs some work to make wheels also on macos
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==1.9.0
-      - name: Install required dependencies
-        run: python -m pip install h5py lalsuite lscsoft-glue matplotlib numpy python-ligo-lw scipy six
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,57 @@
+name: Build Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.9.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+  deploy_pypi:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-20.04
+    needs: build_wheels
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - uses: actions/download-artifact@v2
+      with:
+        path: ./
+    - name: build pycbc for pypi
+      run: |
+        python setup.py sdist
+        mv artifact/* dist/
+    - name: Publish distribution 📦 to Test PyPI
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           # against the lal library. However, the lal library installed through
           # pip is hard to link against. This symlinks it into /usr/lib so
           # that it can be found.
-          CIBW_BEFORE_BUILD: ln -s `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so
+          CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,6 +29,7 @@ jobs:
           # lalsuite currently not available on python3.9. It should be in the
           # very near future though, so add cp39-* here when it is!
           CIBW_BUILD: cp36-* cp37-* cp38-*
+          COBW_ARCHS: auto64
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -26,7 +26,9 @@ jobs:
           # pip is hard to link against. This symlinks it into /usr/lib so
           # that it can be found.
           CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
+          # lalsuite currently not available on python3.9. It should be in the
+          # very near future though, so add cp39-* here when it is!
+          CIBW_BUILD: cp36-* cp37-* cp38-*
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel", "numpy", "cython", "lalsuite"]
+
+build-backend = "setuptools.build_meta"

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,3 +1,5 @@
 pip install lalsuite
 cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/lib*so* /usr/lib
+echo /usr/lib/liblal-*so*
+ls /usr/lib/
 ln -sf /usr/lib/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,3 +1,3 @@
 pip install lalsuite
 cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/lib*so* /usr/lib
-ln -s /usr/lib/liblal-*so* /usr/lib/liblal.so
+ln -sf /usr/lib/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,2 +1,3 @@
 pip install lalsuite
-ln -s `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so
+cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib
+ln -s /usr/lib/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -2,4 +2,4 @@ pip install lalsuite
 cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/lib*so* /usr/lib
 echo /usr/lib/liblal-*so*
 ls /usr/lib/
-ln -sf /usr/lib/liblal-*so* /usr/lib/liblal.so
+ln -sf `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,3 +1,4 @@
+set -e
 # This is used in github actions when building the wheels for distribution.
 # Do not run this outside of that!
 pip install lalsuite

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,3 +1,3 @@
 pip install lalsuite
-cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib
+cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/lib*so* /usr/lib
 ln -s /usr/lib/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,5 +1,5 @@
+# This is used in github actions when building the wheels for distribution.
+# Do not run this outside of that!
 pip install lalsuite
 cp `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/lib*so* /usr/lib
-echo /usr/lib/liblal-*so*
-ls /usr/lib/
 ln -sf `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so

--- a/tools/cibuildwheel_prep.sh
+++ b/tools/cibuildwheel_prep.sh
@@ -1,0 +1,2 @@
+pip install lalsuite
+ln -s `python -c 'import sys; print (sys.path[-1])'`/lalsuite.libs/liblal-*so* /usr/lib/liblal.so


### PR DESCRIPTION
This copies over the distribution.yml file from PyCBC that is responsible for auto-uploading code releases to pypi.

@duncanmmacleod has conda setup to autobuild from pypi, so this would automatically propagate releases to both.

Not entirely sure this will be testable from a pull request. This might be a case of checking what happens *after* this is merged (and after a new release is made!)