### PR TITLE
Get version using attr in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = sbank
+version = attr: sbank.__version__
 author = The Sbank team
 maintainer = Ian Harry
 maintainer_email = ian.harry@ligo.org

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@
 """
 
 import os
-import re
-from pathlib import Path
 
 from setuptools import setup, Extension
 
@@ -15,21 +13,6 @@ import numpy
 from Cython.Build import cythonize
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-
-
-def find_version(path, varname="__version__"):
-    """Parse the version metadata in the given file.
-    """
-    with Path(path).open("r") as fobj:
-        version_file = fobj.read()
-    version_match = re.search(
-        r"^{0} = ['\"]([^'\"]*)['\"]".format(varname),
-        version_file,
-        re.M,
-    )
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
 
 
 # define cython options
@@ -67,6 +50,5 @@ exts = [
 # this function only manually specifies things that aren't
 # supported by setup.cfg (as of setuptools-30.3.0)
 setup(
-    version=find_version(Path("sbank") / "__init__.py"),
     ext_modules=cythonize(exts, compiler_directives=cython_directives),
 )


### PR DESCRIPTION
This PR migrates the `setuptools.setup` metdata option `version` to setup.cfg using the `attr:` fancy thing, which allows us to simplify `setup.py`.