### PR TITLE
Fix test_pypi upload issue

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -60,6 +60,7 @@ jobs:
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
Unlike in PyCBC, we are not using custom version identifiers for non-release tags. This means we cannot upload every commit to test pypi. Adding this flag prevents a failure (hopefully) when the code tries this. It should still do all the testing we want it to do.