### PR TITLE
The which function must return a str object

### DIFF
--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -42,7 +42,7 @@ def which(prog):
     if not out:
         print("ERROR: could not find %s in your path, have you built the proper software and source the proper env. scripts?" % (prog,prog), file=sys.stderr)
         raise ValueError
-    return out
+    return out.decode()
 
 def log_path():
     host = socket.getfqdn()

--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -26,7 +26,7 @@ import os
 import socket
 import sys
 import tempfile
-from shutil import which
+import shutil
 
 ##############################################################################
 # import the modules we need to build the pipeline
@@ -35,6 +35,14 @@ from glue.pipeline import DeepCopyableConfigParser as dcConfigParser
 
 from glue import pipeline
 from lalapps import inspiral
+
+def which(prog):
+    out = shutil.which(prog)
+    if out is None:
+        print("ERROR: could not find %s in your path, have you built the proper software and source the proper env. scripts?" % (prog,prog), file=sys.stderr)
+        raise ValueError
+    return out
+
 
 def log_path():
     host = socket.getfqdn()

--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -27,6 +27,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+from shutil import which
 
 ##############################################################################
 # import the modules we need to build the pipeline
@@ -35,14 +36,6 @@ from glue.pipeline import DeepCopyableConfigParser as dcConfigParser
 
 from glue import pipeline
 from lalapps import inspiral
-
-def which(prog):
-    which = subprocess.Popen(['/usr/bin/which', prog], stdout=subprocess.PIPE)
-    out = which.stdout.read().strip()
-    if not out:
-        print("ERROR: could not find %s in your path, have you built the proper software and source the proper env. scripts?" % (prog,prog), file=sys.stderr)
-        raise ValueError
-    return out.decode()
 
 def log_path():
     host = socket.getfqdn()

--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -39,8 +39,7 @@ from lalapps import inspiral
 def which(prog):
     out = shutil.which(prog)
     if out is None:
-        print("ERROR: could not find %s in your path, have you built the proper software and source the proper env. scripts?" % (prog,prog), file=sys.stderr)
-        raise ValueError
+        raise ValueError("Could not find {} in your path, have you built the proper software and sourced the proper env. scripts?".format(prog))
     return out
 
 

--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -24,7 +24,6 @@ from __future__ import print_function
 import getpass
 import os
 import socket
-import subprocess
 import sys
 import tempfile
 from shutil import which


### PR DESCRIPTION
sbank_pipe currently fails on ligolw_add jobs because the path to the file is returned as a str. I'm not sure if I want to do some larger changes here and make the path to this executable be specified in the ini file. In the meantime I patch the existing method.