### PR TITLE
Don't distribute files generated by cython

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 include python-sbank.spec
 recursive-include debian *
 recursive-include sbank *.c *.pyx
+exclude sbank/overlap_cpu.c


### PR DESCRIPTION
This PR updates the `MANIFEST.in` distribution list to exclude the file(s) that is (are) generated by cython. Downstream package builders should regenerate them on-the-fly anyway.