### PR TITLE
Migrate to python-ligo-lw for LIGO_LW I/O

### DIFF
--- a/bin/sbank
+++ b/bin/sbank
@@ -32,11 +32,11 @@ import h5py
 
 from scipy.interpolate import UnivariateSpline
 
-from glue.ligolw import ligolw
-from glue.ligolw import lsctables
-from glue.ligolw import utils
-from glue.ligolw import ilwd
-from glue.ligolw.utils import process as ligolw_process
+from ligo.lw import ligolw
+from ligo.lw import lsctables
+from ligo.lw import utils
+from ligo.lw import ilwd
+from ligo.lw.utils import process as ligolw_process
 
 #from sbank import git_version FIXME
 from sbank.bank import Bank
@@ -45,9 +45,9 @@ from sbank.psds import (noise_models, read_psd)
 from sbank.waveforms import waveforms, SnglInspiralTable
 
 
+@lsctables.use_in
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
-lsctables.use_in(ContentHandler)
 
 usage = """
 
@@ -461,7 +461,7 @@ opts_dict = dict((k, v) for k, v in opts.__dict__.items()
 if opts.output_filename.endswith(('.xml', '.xml.gz')):
     process = ligolw_process.register_to_xmldoc(xmldoc, "sbank",
         opts_dict, version="no version",
-        cvs_repository="sbank", cvs_entry_time=strftime('%Y/%m/%d %H:%M:%S'))
+        cvs_repository="sbank", cvs_entry_time=strftime('%Y-%m-%d %H:%M:%S +000'))
 
 
 #

--- a/bin/sbank
+++ b/bin/sbank
@@ -139,7 +139,7 @@ def checkpoint_save(xmldoc, fout, process):
 
     # write out the document
     ligolw_process.set_process_end_time(process)
-    utils.write_filename(xmldoc, fout + "_checkpoint.gz",  gz=True)
+    utils.write_filename(xmldoc, fout + "_checkpoint.gz")
 
 
 def parse_command_line():
@@ -469,7 +469,7 @@ if opts.output_filename.endswith(('.xml', '.xml.gz')):
 
 if opts.trial_waveforms:
     if opts.trial_waveforms.endswith(('.xml', '.xml.gz')):
-        trialdoc = utils.load_filename(opts.trial_waveforms, contenthandler=ContentHandler, gz=opts.trial_waveforms.endswith('.gz'))
+        trialdoc = utils.load_filename(opts.trial_waveforms, contenthandler=ContentHandler)
         trial_sngls = lsctables.SnglInspiralTable.get_table(trialdoc)
         proposal = (tmplt_class.from_sngl(t, bank=bank) for t in trial_sngls)
     elif opts.trial_waveforms.endswith(('.hdf', '.h5', '.hdf5')):
@@ -590,8 +590,7 @@ bank.clear()  # clear caches
 # write out the document
 if opts.output_filename.endswith(('.xml', '.xml.gz')):
     ligolw_process.set_process_end_time(process)
-    utils.write_filename(xmldoc, opts.output_filename,
-                         gz=opts.output_filename.endswith("gz"))
+    utils.write_filename(xmldoc, opts.output_filename)
 elif opts.output_filename.endswith(('.hdf', '.h5', '.hdf5')):
     hdf_fp = h5py.File(opts.output_filename, 'w')
     if len(tbl) == 0:

--- a/bin/sbank
+++ b/bin/sbank
@@ -35,7 +35,6 @@ from scipy.interpolate import UnivariateSpline
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils
-from ligo.lw import ilwd
 from ligo.lw.utils import process as ligolw_process
 
 #from sbank import git_version FIXME
@@ -556,10 +555,6 @@ for tmplt in proposal:
         if not hasattr(tmplt, 'is_seed_point'):
             if opts.output_filename.endswith(('.xml', '.xml.gz')):
                 row = tmplt.to_sngl()
-                # Event ids must be unique, or the table isn't valid,
-                # SQL needs this
-                row.event_id = ilwd.ilwdchar('sngl_inspiral:event_id:%d' %
-                                             (len(bank), ))
                 # If we figure out how to use metaio's SnglInspiralTable the
                 # following change then defines the event_id
                 #curr_id = EventIDColumn()
@@ -568,6 +563,7 @@ for tmplt in proposal:
                 #row.event_id = curr_id
                 row.ifo = opts.instrument
                 row.process_id = process.process_id
+                row.event_id = tbl.get_next_id()
                 tbl.append(row)
             if opts.output_filename.endswith(('.hdf', '.h5', '.hdf5')):
                 row = tmplt.to_storage_arr()

--- a/bin/sbank_choose_mchirp_boundaries
+++ b/bin/sbank_choose_mchirp_boundaries
@@ -34,12 +34,12 @@ from optparse import OptionParser
 
 import numpy
 
-from glue.ligolw import (ligolw, lsctables, utils)
+from ligo.lw import (ligolw, lsctables, utils)
 
 
+@lsctables.use_in
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
-lsctables.use_in(ContentHandler)
 
 def parse_command_line():
     parser = OptionParser(usage=__doc__)

--- a/bin/sbank_sim
+++ b/bin/sbank_sim
@@ -27,8 +27,8 @@ import numpy as np
 from h5py import File as H5File
 
 from scipy.interpolate import UnivariateSpline
-from glue.ligolw import (ligolw, lsctables, utils)
-from glue.ligolw.utils import (ligolw_add, process as ligolw_process)
+from ligo.lw import (ligolw, lsctables, utils)
+from ligo.lw.utils import (ligolw_add, process as ligolw_process)
 
 import lalsimulation as lalsim
 from lal import MSUN_SI
@@ -37,13 +37,13 @@ from sbank.bank import Bank
 from sbank.waveforms import waveforms
 from sbank.psds import noise_models, read_psd
 
+@lsctables.use_in
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
-lsctables.use_in(ContentHandler)
 
 def ligolw_table_to_array(tab):
     # get mapping of LIGO_LW types to numpy numeric types; add string types
-    from glue.ligolw.types import ToNumPyType
+    from ligo.lw.types import ToNumPyType
     type_map = ToNumPyType.copy()
     type_map[u"ilwd:char"] = "S40"
     type_map[u"lstring"] = "S32"

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  python3-ligo-lw-bin | ligo-lw-bin,
  python3-matplotlib,
  python3-numpy,
- python3-pytest,
+ python3-pytest (>= 3.9.1),
  python3-scipy,
  python3-six,
  python3-setuptools (>= 30.3.0),

--- a/python-sbank.spec
+++ b/python-sbank.spec
@@ -45,7 +45,9 @@ BuildRequires: python%{python3_pkgversion}-scipy
 BuildRequires: python%{python3_pkgversion}-six
 
 # testing dependencies (required for %check)
-BuildRequires: python%{python3_pkgversion}-pytest
+%if 0%{?rhel} == 0 || 0%{?rhel} >= 9
+BuildRequires: python%{python3_pkgversion}-pytest >= 3.9.1
+%endif
 
 # -- src rpm ----------------
 
@@ -113,7 +115,9 @@ mkdir -p _tests
 cd _tests
 export PATH="%{buildroot}%{_bindir}:${PATH}"
 export PYTHONPATH="%{buildroot}%{python3_sitearch}:%{buildroot}%{python3_sitelib}:${PYTHONPATH}"
+%if 0%{?rhel} == 0 || 0%{?rhel} >= 9
 %{__python3} -m pytest --color=yes --pyargs %{srcname}
+%endif
 sbank --help
 
 %install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage
-pytest
+pytest >= 3.9.1
 pytest-cov
 numpy
 cython

--- a/sbank/psds.py
+++ b/sbank/psds.py
@@ -23,7 +23,7 @@ import lalsimulation as lalsim
 import lal
 from lal import series as lalseries
 
-from glue.ligolw import (param, utils)
+from ligo.lw import (param, utils)
 
 seterr(over="ignore")  # the PSD overflows frequently, but that's OK
 

--- a/sbank/tests/test_psds.py
+++ b/sbank/tests/test_psds.py
@@ -8,6 +8,56 @@ import pytest
 
 from .. import psds as sbank_psds
 
+LIGO_LW_ARRAY = """<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE LIGO_LW SYSTEM "http://ldas-sw.ligo.caltech.edu/doc/ligolwAPI/html/ligolw_dtd.txt">
+<LIGO_LW Name="psd">
+  <LIGO_LW Name="REAL8FrequencySeries">
+    <Time Type="GPS" Name="epoch">0</Time>
+    <Param Name="f0:param" Type="real_8" Unit="s^-1">0</Param>
+    <Array Type="real_8" Name="aLIGOZeroDetHighPower:array" Unit="s">
+      <Dim Name="Frequency" Unit="s^-1" Start="0" Scale="1">11</Dim>
+      <Dim Name="Frequency,Real">2</Dim>
+      <Stream Type="Local" Delimiter=" ">
+        0 0
+        1 5.870471766089542e-40
+        2 1.962088320602432e-41
+        3 2.751143271999274e-42
+        4 6.92354999020744e-43
+        5 2.39732692753636e-43
+        6 1.014780466036667e-43
+        7 4.931072304135098e-44
+        8 2.649571891648038e-44
+        9 1.536838230224327e-44
+        10 9.466734353467912e-45
+      </Stream>
+    </Array>
+    <Param Name="instrument:param" Type="lstring">H1</Param>
+  </LIGO_LW>
+  <LIGO_LW Name="REAL8FrequencySeries">
+    <Time Type="GPS" Name="epoch">0</Time>
+    <Param Name="f0:param" Type="real_8" Unit="s^-1">0</Param>
+    <Array Type="real_8" Name="aLIGOZeroDetHighPower:array" Unit="s">
+      <Dim Name="Frequency" Unit="s^-1" Start="0" Scale="1">11</Dim>
+      <Dim Name="Frequency,Real">2</Dim>
+      <Stream Type="Local" Delimiter=" ">
+        0 0
+        1 5.870471766089542e-40
+        2 1.962088320602432e-41
+        3 2.751143271999274e-42
+        4 6.92354999020744e-43
+        5 2.39732692753636e-43
+        6 1.014780466036667e-43
+        7 4.931072304135098e-44
+        8 2.649571891648038e-44
+        9 1.536838230224327e-44
+        10 9.466734353467912e-45
+      </Stream>
+    </Array>
+    <Param Name="instrument:param" Type="lstring">L1</Param>
+  </LIGO_LW>
+</LIGO_LW>
+"""  # noqa: E501
+
 
 @pytest.mark.parametrize("arg, result", (
     (1, 1),
@@ -17,3 +67,11 @@ from .. import psds as sbank_psds
 ))
 def test_next(arg, result):
     assert sbank_psds.next_pow2(arg) == result
+
+
+def test_read_psds(tmp_path):
+    llwf = tmp_path / "test.xml"
+    llwf.write_text(LIGO_LW_ARRAY)
+    psd = sbank_psds.read_psd(llwf)
+    for ifo in ("H1", "L1"):
+        assert psd[ifo].data.data.size == 11

--- a/sbank/waveforms.py
+++ b/sbank/waveforms.py
@@ -26,19 +26,19 @@ import lal
 import lalsimulation as lalsim
 from lal import MSUN_SI, MTSUN_SI, PC_SI, PI
 from lal import CreateREAL8Vector, CreateCOMPLEX8FrequencySeries
-from glue.ligolw.lsctables import SnglInspiralTable as gluesit
+from ligo.lw.lsctables import SnglInspiralTable as llwsit
 
 from .overlap import SBankComputeMatchSkyLoc, SBankComputeMatch
 from .psds import get_neighborhood_PSD, get_ASD
 from .tau0tau3 import m1m2_to_tau0tau3
 
 np.seterr(all="ignore")
-_sit_cols = gluesit.validcolumns
+_sit_cols = llwsit.validcolumns
 
 
-class SnglInspiralTable(gluesit):
+class SnglInspiralTable(llwsit):
     def __init__(self, *args, **kwargs):
-        gluesit.__init__(self, *args, **kwargs)
+        llwsit.__init__(self, *args, **kwargs)
         for entry in _sit_cols.keys():
             if not(hasattr(self, entry)):
                 if _sit_cols[entry] in ['real_4', 'real_8']:


### PR DESCRIPTION
This PR migrates all LIGO_LW I/O in this package to use `python-ligo-lw` instead of the (deprecated) `glue.ligolw` package. This is mainly porting of commits already present in lscsoft/lalsuite.