### PR TITLE
Remove all references to dax/pegasus

### DIFF
--- a/bin/sbank_pipe
+++ b/bin/sbank_pipe
@@ -63,7 +63,7 @@ class bank_DAG(pipeline.CondorDAG):
         logfile = tempfile.mktemp()
         fh = open( logfile, "w" )
         fh.close()
-        pipeline.CondorDAG.__init__(self,logfile, dax=False)
+        pipeline.CondorDAG.__init__(self,logfile)
         self.set_dag_file(self.basename)
         self.jobsDict = {}
         self.node_id = 0
@@ -84,11 +84,11 @@ class bank_DAG(pipeline.CondorDAG):
 
 
 class SBankJob(inspiral.InspiralAnalysisJob):
-    def __init__(self,cp,dax=False, tag_base="sbank"):
+    def __init__(self,cp, tag_base="sbank"):
         exec_name = 'sbank'
         extension = 'xml'
         sections = ['sbank']
-        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension,dax)
+        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension)
         self.tag_base = tag_base
         self.set_sub_file(tag_base+'.sub')
         self.set_stdout_file('logs/'+tag_base+'-$(macroid)-$(process).out')
@@ -125,11 +125,11 @@ class SBankNode(pipeline.CondorDAGNode):
 
 
 class SBankChooseMchirpBoundariesJob(inspiral.InspiralAnalysisJob):
-    def __init__(self,cp,dax=False, tag_base="sbank_choose_mchirp_boundaries"):
+    def __init__(self,cp, tag_base="sbank_choose_mchirp_boundaries"):
         exec_name = 'sbank_choose_mchirp_boundaries'
         extension = 'txt'
         sections = ['split']
-        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension,dax)
+        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension)
         self.set_universe("local")
         self.set_sub_file(tag_base+'.sub')
         self.tag_base = tag_base

--- a/bin/sbank_sim_pipe
+++ b/bin/sbank_sim_pipe
@@ -57,9 +57,8 @@ class bank_DAG(pipeline.CondorDAG):
         logfile = tempfile.mktemp()
         fh = open( logfile, "w" )
         fh.close()
-        pipeline.CondorDAG.__init__(self,logfile, dax=False)
+        pipeline.CondorDAG.__init__(self,logfile)
         self.set_dag_file(self.basename)
-        self.set_dax_file(self.basename)
         self.jobsDict = {}
         self.node_id = 0
         self.output_cache = []
@@ -78,11 +77,11 @@ class bank_DAG(pipeline.CondorDAG):
         f.close()
 
 class InspinjJob(inspiral.InspiralAnalysisJob):
-    def __init__(self, cp, dax=False, tag_base="inspinj"):
+    def __init__(self, cp, tag_base="inspinj"):
         exec_name = 'lalapps_inspinj'
         extension = 'xml'
         sections = ['inspinj']
-        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension,dax)
+        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension)
         self.set_universe("local")
         self.set_sub_file(tag_base+'.sub')
         self.tag_base = tag_base
@@ -108,11 +107,11 @@ class InspinjNode(pipeline.CondorDAGNode):
         dag.add_node(self)
 
 class BankSimJob(inspiral.InspiralAnalysisJob):
-    def __init__(self, cp, dax=False, tag_base ="banksim"):
+    def __init__(self, cp, tag_base ="banksim"):
         exec_name = 'sbank_sim'
         extension = 'xml'
         sections = ['banksim']
-        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension,dax)
+        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension)
         self.add_condor_cmd('request_memory', '3999')
         self.tag_base = tag_base
         self.add_condor_cmd('getenv','True')
@@ -140,11 +139,11 @@ class BankSimNode(pipeline.CondorDAGNode):
 
 
 class PlotSimJob(inspiral.InspiralAnalysisJob):
-    def __init__(self, cp, dax=False, tag_base="sbank_plot_sim"):
+    def __init__(self, cp, tag_base="sbank_plot_sim"):
         exec_name = 'sbank_plot_sim'
         extension = 'h5'
         sections = []
-        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension,dax)
+        inspiral.InspiralAnalysisJob.__init__(self,cp,sections,exec_name,extension)
         self.tag_base = tag_base
         self.set_universe("local")
         self.set_sub_file(tag_base+'.sub')


### PR DESCRIPTION
This PR removes lingering dax/pegasus references in the sbank scripts, this is a manual cherry-pick of lscsoft/lalsuite@102e7069078f1bb9b087c9a0f9438bdac789841c.