### PR TITLE
Fixes and new tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,9 @@ jobs:
                 ${script} --help
         done
 
+    - name: Run short sbank executable tests
+      run: bash tools/test_sbank.sh
+
     - name: Coverage report
       run: python -m coverage report --show-missing
 

--- a/bin/sbank
+++ b/bin/sbank
@@ -599,7 +599,7 @@ elif opts.output_filename.endswith(('.hdf', '.h5', '.hdf5')):
     else:
         params = tbl.dtype.names
         # This would be less clunky if I could use a modern HDF version!!!
-        params_b = [bytes(p, 'utf-8') for p in params]
+        params_b = [p.encode('utf-8') for p in params]
         hdf_fp.attrs['parameters'] = params_b
         for param in params:
             hdf_fp[param] = tbl[param]

--- a/bin/sbank
+++ b/bin/sbank
@@ -138,7 +138,7 @@ def checkpoint_save(xmldoc, fout, process):
              state4=np.array(rng_state[4]))
 
     # write out the document
-    ligolw_process.set_process_end_time(process)
+    process.set_end_time_now()
     utils.write_filename(xmldoc, fout + "_checkpoint.gz")
 
 
@@ -460,7 +460,8 @@ opts_dict = dict((k, v) for k, v in opts.__dict__.items()
 if opts.output_filename.endswith(('.xml', '.xml.gz')):
     process = ligolw_process.register_to_xmldoc(xmldoc, "sbank",
         opts_dict, version="no version",
-        cvs_repository="sbank", cvs_entry_time=strftime('%Y-%m-%d %H:%M:%S +000'))
+        cvs_repository="sbank",
+        cvs_entry_time=strftime('%Y-%m-%d %H:%M:%S +0000'))
 
 
 #
@@ -589,7 +590,7 @@ bank.clear()  # clear caches
 
 # write out the document
 if opts.output_filename.endswith(('.xml', '.xml.gz')):
-    ligolw_process.set_process_end_time(process)
+    process.set_end_time_now()
     utils.write_filename(xmldoc, opts.output_filename)
 elif opts.output_filename.endswith(('.hdf', '.h5', '.hdf5')):
     hdf_fp = h5py.File(opts.output_filename, 'w')
@@ -597,6 +598,8 @@ elif opts.output_filename.endswith(('.hdf', '.h5', '.hdf5')):
         hdf_fp.attrs['empty_file'] = True
     else:
         params = tbl.dtype.names
-        hdf_fp.attrs['parameters'] = params
+        # This would be less clunky if I could use a modern HDF version!!!
+        params_b = [bytes(p, 'utf-8') for p in params]
+        hdf_fp.attrs['parameters'] = params_b
         for param in params:
             hdf_fp[param] = tbl[param]

--- a/bin/sbank_sim
+++ b/bin/sbank_sim
@@ -247,7 +247,7 @@ lsctables.reset_next_ids((lsctables.ProcessTable, lsctables.ProcessParamsTable))
 ligolw_add.reassign_ids(fake_xmldoc)
 ligolw_add.merge_ligolws(fake_xmldoc)
 ligolw_add.merge_compatible_tables(fake_xmldoc)
-ligolw_process.set_process_end_time(process)
+process.set_end_time_now()
 
 # output process
 proc = lsctables.ProcessTable.get_table(fake_xmldoc)

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -1,3 +1,4 @@
+set -e
 # Run sbank to generate XML and HDF banks
 ./sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 45
 

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -1,0 +1,17 @@
+# Run sbank to generate XML and HDF banks
+./sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 45
+
+./sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
+
+XML_SIZE=`ligolw_print BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml -t sngl_inspiral | wc -l`
+HDF_SIZE=`h5ls BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf | grep "spin1z" | awk '{print $3}'`
+HDF_SIZE="${HDF_SIZE:1:3}"
+
+if ((XML_SIZE >= 140 && XML_SIZE <= 160)); then
+  exit 1
+fi
+
+if ((HDF_SIZE >= 240 && HDF_SIZE <= 260)); then
+  exit 1
+fi
+

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -1,6 +1,6 @@
 set -e
 # Run sbank to generate XML and HDF banks
-sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 45
+sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 25
 
 sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
 
@@ -9,10 +9,12 @@ HDF_SIZE=`h5ls BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf | grep "spin1z" | awk '{
 HDF_SIZE="${HDF_SIZE:1:3}"
 
 if ((XML_SIZE < 140 || XML_SIZE > 160)); then
+  echo "The XML bank is not the expected size " ${XML_SIZE}
   exit 1
 fi
 
-if ((HDF_SIZE < 240 || HDF_SIZE > 260)); then
+if ((HDF_SIZE < 140 || HDF_SIZE > 160)); then
+  echo "The HDF bank is not the expected size " ${HDF_SIZE}
   exit 1
 fi
 

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -1,8 +1,12 @@
 set -e
-# Run sbank to generate XML and HDF banks
-sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 25
 
-sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
+PREFIX=$(python -c "import sys; print(sys.prefix)")
+PYTHON="python -m coverage run --append"
+
+# Run sbank to generate XML and HDF banks
+${PYTHON} ${PREFIX}/bin/sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 25
+
+${PYTHON} ${PREFIX}/bin/sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
 
 XML_SIZE=`ligolw_print BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml -t sngl_inspiral | wc -l`
 HDF_SIZE=`h5ls BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf | grep "spin1z" | awk '{print $3}'`

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -8,11 +8,11 @@ XML_SIZE=`ligolw_print BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml -t sngl_inspiral
 HDF_SIZE=`h5ls BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf | grep "spin1z" | awk '{print $3}'`
 HDF_SIZE="${HDF_SIZE:1:3}"
 
-if ((XML_SIZE >= 140 && XML_SIZE <= 160)); then
+if ((XML_SIZE < 140 || XML_SIZE > 160)); then
   exit 1
 fi
 
-if ((HDF_SIZE >= 240 && HDF_SIZE <= 260)); then
+if ((HDF_SIZE < 240 || HDF_SIZE > 260)); then
   exit 1
 fi
 

--- a/tools/test_sbank.sh
+++ b/tools/test_sbank.sh
@@ -1,8 +1,8 @@
 set -e
 # Run sbank to generate XML and HDF banks
-./sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 45
+sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml --convergence-threshold 45
 
-./sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
+sbank --approximant IMRPhenomD --aligned-spin --mass1-min 15.0 --mass1-max 25.0 --spin1-min 0.0 --spin1-max 0.5 --match-min 0.97 --flow 20.0 --noise-model aLIGOZeroDetHighPower --output-filename BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf --convergence-threshold 25
 
 XML_SIZE=`ligolw_print BBH-IMRPhenomD-aLIGOZeroDetHighPower.xml -t sngl_inspiral | wc -l`
 HDF_SIZE=`h5ls BBH-IMRPhenomD-aLIGOZeroDetHighPower.hdf | grep "spin1z" | awk '{print $3}'`


### PR DESCRIPTION
There's some issues with the new sbank v1.0.0 release on the LVC clusters. I think one of these issues is code removed in ligo.lw, one of these appears to be related to having to use an old H5py version but one might just be something we missed in porting to ligo.lw.

I think that having a "run sbank" test in the github workflows is clearly needed, so I added that too, using one of Steve P's original examples. (I'm going to start with having that fail to make sure it catches issues, and then correct the two issues in the test script).