### PR TITLE
Use centos:7 container for rpmlint in CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -378,7 +378,7 @@ jobs:
   lint-rhel:
     name: Lint RPMs
     runs-on: ubuntu-latest
-    container: centos:8
+    container: centos:7
     needs:
       - rhel-binary
     steps:
@@ -389,7 +389,7 @@ jobs:
 
       - name: Install rpmlint
         run: |
-          dnf -y -q install \
+          yum -y -q install \
               rpmlint \
           ;
 


### PR DESCRIPTION
This PR fixes the broken `rpmlint` CI job.