### PR TITLE
Add support for SEOBNRv5 and IMRPhenomXAS waveforms

### DIFF
--- a/sbank/tau0tau3.py
+++ b/sbank/tau0tau3.py
@@ -651,6 +651,7 @@ proposals = {
     "IMRPhenomB": IMRPhenomB_param_generator,
     "IMRPhenomC": IMRPhenomC_param_generator,
     "IMRPhenomD": aligned_spin_param_generator,
+    "IMRPhenomXAS": aligned_spin_param_generator,
     "TaylorF2": aligned_spin_param_generator,
     "IMRPhenomP": double_spin_precessing_param_generator,
     "IMRPhenomPv2": double_spin_precessing_param_generator,

--- a/sbank/tau0tau3.py
+++ b/sbank/tau0tau3.py
@@ -662,6 +662,8 @@ proposals = {
     "SEOBNRv2_ROM_DoubleSpin_HI": aligned_spin_param_generator,
     "SEOBNRv4": aligned_spin_param_generator,
     "SEOBNRv4_ROM": aligned_spin_param_generator,
+    "SEOBNRv5": aligned_spin_param_generator,
+    "SEOBNRv5_ROM": aligned_spin_param_generator,
     "SpinTaylorT4": SpinTaylorT4_param_generator,
     "SpinTaylorF2": single_spin_precessing_param_generator,
     "SpinTaylorT5Fourier": double_spin_precessing_param_generator,

--- a/sbank/waveforms.py
+++ b/sbank/waveforms.py
@@ -522,6 +522,25 @@ class SEOBNRv4ROMTemplate(SEOBNRv4Template):
     approximant = "SEOBNRv4_ROM"
 
 
+class SEOBNRv5Template(IMRAlignedSpinTemplate):
+    approximant = "SEOBNRv5"
+
+    def _get_dur(self):
+        dur = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
+            self.flow,
+            self.m1 * MSUN_SI,
+            self.m2 * MSUN_SI,
+            self.spin1z,
+            self.spin2z
+        )
+        # Allow a 10% margin of error
+        return dur * 1.1
+
+
+class SEOBNRv5ROMTemplate(SEOBNRv5Template):
+    approximant = "SEOBNRv5_ROM"
+
+
 class EOBNRv2Template(SEOBNRv2Template):
     approximant = "EOBNRv2"
     param_names = ("m1", "m2")
@@ -993,8 +1012,10 @@ waveforms = {
     "SEOBNRv2": SEOBNRv2Template,
     "SEOBNRv2_ROM_DoubleSpin": SEOBNRv2ROMDoubleSpinTemplate,
     "SEOBNRv2_ROM_DoubleSpin_HI": SEOBNRv2ROMDoubleSpinHITemplate,
-    "SEOBNRv4": SEOBNRv4ROMTemplate,
+    "SEOBNRv4": SEOBNRv4Template,
     "SEOBNRv4_ROM": SEOBNRv4ROMTemplate,
+    "SEOBNRv5": SEOBNRv5Template,
+    "SEOBNRv5_ROM": SEOBNRv5ROMTemplate,
     "EOBNRv2": EOBNRv2Template,
     "SpinTaylorT4": SpinTaylorT4Template,
     "SpinTaylorT5": SpinTaylorT5Template,

--- a/sbank/waveforms.py
+++ b/sbank/waveforms.py
@@ -486,6 +486,22 @@ class IMRPhenomDTemplate(IMRAlignedSpinTemplate):
         return dur * 1.1
 
 
+class IMRPhenomXASTemplate(IMRAlignedSpinTemplate):
+    approximant = "IMRPhenomXAS"
+
+    def _get_dur(self):
+        dur = lalsim.SimIMRPhenomXASDuration(
+            self.m1 * MSUN_SI,
+            self.m2 * MSUN_SI,
+            self.spin1z,
+            self.spin2z,
+            self.flow
+        )
+        # add a 10% to be consistent with PyCBC's duration estimate,
+        # may want to FIXME if that changes
+        return dur * 1.1
+
+
 class SEOBNRv2Template(IMRAlignedSpinTemplate):
     approximant = "SEOBNRv2"
 
@@ -1009,6 +1025,7 @@ waveforms = {
     "IMRPhenomD": IMRPhenomDTemplate,
     "IMRPhenomP": IMRPhenomPTemplate,
     "IMRPhenomPv2": IMRPhenomPv2Template,
+    "IMRPhenomXAS": IMRPhenomXASTemplate,
     "SEOBNRv2": SEOBNRv2Template,
     "SEOBNRv2_ROM_DoubleSpin": SEOBNRv2ROMDoubleSpinTemplate,
     "SEOBNRv2_ROM_DoubleSpin_HI": SEOBNRv2ROMDoubleSpinHITemplate,


### PR DESCRIPTION
This adds support for the SEOBNRv5, SEOBNRv5_ROM and IMRPhenomXAS waveform models. Note that I also fixed what *I think* was a typo: SEOBNRv4 was being associated with the `SEOBNRv4ROMTemplate` class, while I assume it should be associated with `SEOBNRv4Template` instead. The two classes appear to be functionally equivalent, so this was probably harmless. Please correct me if this is not right.

I have not tested this.