### PR TITLE
Update distribution.yml to see if it can build new python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         key: ${{ runner.os }}-conda-${{ matrix.python-version}}-${{ env.CACHE_NUMBER }}
 
     - name: Configure conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test
         channels: conda-forge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+        run: python -m pip install cibuildwheel==2.17.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,8 +29,8 @@ jobs:
           CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
           CIBW_BUILD: cp36-manylinux* cp37-manylinux* cp38-manylinux* cp39-manylinux* cp310-manylinux* cp311-manylinux* cp312-manylinux*
           CIBW_ARCHS: auto64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -27,7 +27,7 @@ jobs:
           # pip is hard to link against. This symlinks it into /usr/lib so
           # that it can be found.
           CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
+          CIBW_BUILD: cp36-manylinux* cp37-manylinux* cp38-manylinux* cp39-manylinux* cp310-manylinux* cp311-manylinux* cp312-manylinux*
           CIBW_ARCHS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -27,7 +27,7 @@ jobs:
           # pip is hard to link against. This symlinks it into /usr/lib so
           # that it can be found.
           CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
           CIBW_ARCHS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -27,7 +27,7 @@ jobs:
           # pip is hard to link against. This symlinks it into /usr/lib so
           # that it can be found.
           CIBW_BEFORE_BUILD: bash tools/cibuildwheel_prep.sh
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
           CIBW_ARCHS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux2014


### PR DESCRIPTION
sbank is currently installed as a companion to a pycbc env. If we want to allow python3.12, we also need the wheels from here. 

