### PR TITLE
Add missing lal declarations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         key: ${{ runner.os }}-conda-${{ matrix.python-version}}-${{ env.CACHE_NUMBER }}
 
     - name: Configure conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test
         channels: conda-forge

--- a/sbank/overlap_cpu_lib.c
+++ b/sbank/overlap_cpu_lib.c
@@ -23,6 +23,8 @@
 #include <sys/types.h>
 
 /* ---------------- LAL STUFF NEEDED ----------------- */
+int XLALPrintError(const char *fmt, ...)
+
 typedef struct tagCOMPLEX8Vector {
      uint32_t length; /**< Number of elements in array. */
      float complex *data; /**< Pointer to the data array. */
@@ -34,6 +36,8 @@ void XLALDestroyCOMPLEX8Vector ( COMPLEX8Vector * vector );
 typedef struct tagCOMPLEX8FFTPlan COMPLEX8FFTPlan;
 
 COMPLEX8FFTPlan * XLALCreateReverseCOMPLEX8FFTPlan( uint32_t size, int measurelvl );
+
+int XLALCOMPLEX8VectorFFT (COMPLEX8Vector * restrict output, const COMPLEX8Vector * restrict input, const COMPLEX8FFTPlan *plan);
 
 void XLALDestroyCOMPLEX8FFTPlan( COMPLEX8FFTPlan *plan );
 

--- a/sbank/overlap_cpu_lib.c
+++ b/sbank/overlap_cpu_lib.c
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 
 /* ---------------- LAL STUFF NEEDED ----------------- */
-int XLALPrintError(const char *fmt, ...)
+int XLALPrintError(const char *fmt, ...);
 
 typedef struct tagCOMPLEX8Vector {
      uint32_t length; /**< Number of elements in array. */


### PR DESCRIPTION
@duncanmmacleod Reported that sbank is failing to build on newest clang releases due to missing declarations. This adds the missing declarations (hopefully). Can you approve (if this passes tests etc.)?

@duncanmmacleod A related request to you: I shouldn't have to be doing this! As with numpy, there should be some way to find lalsuite's `.h` files, so I can just include them. I also need a way to find lalsuite's `so` files to link against, which doesn't require the horrible hack that `sbank`'s packaging currently has. Adding these would greatly increase the ability to use Cython with lalsuite (this is better than SWIG because I can interact directly at the C layer).