### PR TITLE
Update pypi action to released

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -56,13 +56,13 @@ jobs:
         mv artifact/* dist/
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
From the CI before this change: (see [here](https://github.com/gwastro/sbank/actions/runs/12431934211/job/34710595549#step:7:9))

`
Warning:  You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.
`

Note that this happens on push to master, so wouldnt be tested in the CI of this PR:
 `if: github.event_name == 'push' && github.ref == 'refs/heads/master'`